### PR TITLE
Change the instance_type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_autoscaling_group" "this" {
         version            = "$Latest"
       }
       dynamic "override" {
-        for_each = ["t2.micro"]
+        for_each = ["t2.small"]
         content {
           instance_type = override.value
         }


### PR DESCRIPTION
This PR fixes the instance type as there are no `t2.micro` spot instance available in the region.