### PR TITLE
Tweaks to smooth creation of bucket and adapt to new location of SOPS

### DIFF
--- a/data/init.sh
+++ b/data/init.sh
@@ -92,10 +92,11 @@ chmod a+x /usr/local/bin/docker-compose
 
 # Install mozilla sops
 # renovate: datasource=github-releases depName=mozilla/sops versioning=semver
-export ENV_SOPS_VERSION="v3.9.0"
-curl -L "https://github.com/mozilla/sops/releases/download/$ENV_SOPS_VERSION/sops-$(echo $ENV_SOPS_VERSION | cut -c2-).x86_64.rpm" -o "/tmp/sops-$(echo $ENV_SOPS_VERSION | cut -c2-).x86_64.rpm"
-rpm -i "/tmp/sops-$(echo $ENV_SOPS_VERSION | cut -c2-).x86_64.rpm"
-rm -f "/tmp/sops-$(echo $ENV_SOPS_VERSION | cut -c2-).x86_64.rpm"
+export ENV_SOPS_VERSION="3.9.0"
+export ENV_SOPS_SUB_VERSION="1"
+curl -L "https://github.com/getsops/sops/releases/download/v$ENV_SOPS_VERSION/sops-$ENV_SOPS_VERSION-$ENV_SOPS_SUB_VERSION.x86_64.rpm" -o "/tmp/sops-$ENV_SOPS_VERSION.x86_64.rpm"
+rpm -i "/tmp/sops-$ENV_SOPS_VERSION.x86_64.rpm"
+rm -f "/tmp/sops-$ENV_SOPS_VERSION.x86_64.rpm"
 
 # Get the secrets
 aws s3 cp "s3://${resources_bucket}/${bitwarden_env_key}" /home/ec2-user/conf/compose/env.enc

--- a/s3.tf
+++ b/s3.tf
@@ -13,6 +13,14 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_acl" "bucket" {
   bucket = aws_s3_bucket.bucket.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.bucket]
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+      object_ownership = "ObjectWriter"
+  }
 }
 
 resource "aws_s3_bucket_versioning" "bucket" {
@@ -70,6 +78,7 @@ resource "aws_s3_bucket" "resources" {
 resource "aws_s3_bucket_acl" "resources" {
   bucket = aws_s3_bucket.resources.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.resources]
 }
 
 resource "aws_s3_bucket_versioning" "resources" {
@@ -77,6 +86,13 @@ resource "aws_s3_bucket_versioning" "resources" {
 
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "resources" {
+  bucket = aws_s3_bucket.resources.id
+  rule {
+      object_ownership = "ObjectWriter"
   }
 }
 


### PR DESCRIPTION
I wanted to update to the newer code from your repo but found I needed a couple of changes to get the instance to start up:

- The location of SOPS seems to have changed
- I get an error that ACLs can't be assigned to the bucket

With these changes the instance starts up, however there is another problem that traefik doesn't create the certificates. To debug further will involve learning a bit more about what it is doing. I'll try and have a look at that after my vacation.